### PR TITLE
throw IllegalStateException if binding accessed before view created or after destroyed

### DIFF
--- a/bindables/src/main/java/com/skydoves/bindables/BindingBottomSheetDialogFragment.kt
+++ b/bindables/src/main/java/com/skydoves/bindables/BindingBottomSheetDialogFragment.kt
@@ -52,7 +52,9 @@ abstract class BindingBottomSheetDialogFragment<T : ViewDataBinding> constructor
    */
   @BindingOnly
   protected val binding: T
-    get() = _binding!!
+    get() = checkNotNull(_binding) {
+      "BottomSheetDialogFragment $this binding cannot be accessed before onCreateView() or after onDestroyView()"
+    }
 
   /**
    * An executable inline binding function that receives a binding receiver in lambda.

--- a/bindables/src/main/java/com/skydoves/bindables/BindingDialogFragment.kt
+++ b/bindables/src/main/java/com/skydoves/bindables/BindingDialogFragment.kt
@@ -52,7 +52,9 @@ abstract class BindingDialogFragment<T : ViewDataBinding> constructor(
    */
   @BindingOnly
   protected val binding: T
-    get() = _binding!!
+    get() = checkNotNull(_binding) {
+      "DialogFragment $this binding cannot be accessed before onCreateView() or after onDestroyView()"
+    }
 
   /**
    * An executable inline binding function that receives a binding receiver in lambda.

--- a/bindables/src/main/java/com/skydoves/bindables/BindingFragment.kt
+++ b/bindables/src/main/java/com/skydoves/bindables/BindingFragment.kt
@@ -52,7 +52,9 @@ abstract class BindingFragment<T : ViewDataBinding> constructor(
    */
   @BindingOnly
   protected val binding: T
-    get() = _binding!!
+    get() = checkNotNull(_binding) {
+      "Fragment $this binding cannot be accessed before onCreateView() or after onDestroyView()"
+    }
 
   /**
    * An executable inline binding function that receives a binding receiver in lambda.


### PR DESCRIPTION

## Guidelines
throw `IllegalStateException` instead of `NullPointerException` if view binding is accessed before onCreateView() or after onDestroyView()

### Types of changes
What types of changes does your code introduce?
- 

### Preparing a pull request for review
Ensure your change is properly formatted by running:

```gradle
$ ./gradlew spotlessApply
```

Please correct any failures before requesting a review.